### PR TITLE
FBCM-5157 Allow multiple SetCookie headers in response

### DIFF
--- a/src/HTTPure/Headers.purs
+++ b/src/HTTPure/Headers.purs
@@ -10,10 +10,11 @@ module HTTPure.Headers
 import Prelude
 
 import Data.Foldable (foldl)
-import Data.FoldableWithIndex (foldMapWithIndex)
+import Data.Generic.Rep (class Generic)
 import Data.Map (Map, insert, singleton, union)
 import Data.Map (empty) as Map
 import Data.Newtype (class Newtype, unwrap)
+import Data.Show.Generic (genericShow)
 import Data.String.CaseInsensitive (CaseInsensitiveString(CaseInsensitiveString))
 import Data.TraversableWithIndex (traverseWithIndex)
 import Data.Tuple (Tuple(Tuple))
@@ -28,24 +29,21 @@ newtype Headers = Headers (Map CaseInsensitiveString String)
 
 derive instance newtypeHeaders :: Newtype Headers _
 
+derive instance genericHeaders :: Generic Headers _
+
 -- | Given a string, return a `Maybe` containing the value of the matching
 -- | header, if there is any.
-instance lookup :: Lookup Headers String String where
+instance lookupHeaders :: Lookup Headers String String where
   lookup (Headers headers') key = headers' !! key
 
--- | Allow a `Headers` to be represented as a string. This string is formatted
--- | in HTTP headers format.
-instance show :: Show Headers where
-  show (Headers headers') = foldMapWithIndex showField headers' <> "\n"
-    where
-    showField key value = unwrap key <> ": " <> value <> "\n"
+instance showHeaders :: Show Headers where
+  show = genericShow
 
 -- | Compare two `Headers` objects by comparing the underlying `Objects`.
-instance eq :: Eq Headers where
-  eq (Headers a) (Headers b) = eq a b
+derive newtype instance eqHeaders :: Eq Headers
 
 -- | Allow one `Headers` objects to be appended to another.
-instance semigroup :: Semigroup Headers where
+instance semigroupHeaders :: Semigroup Headers where
   append (Headers a) (Headers b) = Headers $ union b a
 
 -- | Get the headers out of a HTTP `Request` object.

--- a/src/HTTPure/MultiHeaders.purs
+++ b/src/HTTPure/MultiHeaders.purs
@@ -1,0 +1,107 @@
+module HTTPure.MultiHeaders
+  ( MultiHeaders(..)
+  , empty
+  , header
+  , header'
+  , headers
+  , headers'
+  , read
+  , write
+  ) where
+
+import Prelude
+
+import Data.Array.NonEmpty (NonEmptyArray)
+import Data.Array.NonEmpty as Data.Array.NonEmpty
+import Data.Foldable (foldl)
+import Data.Generic.Rep (class Generic)
+import Data.Map (Map)
+import Data.Map as Data.Map
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype, unwrap)
+import Data.Show.Generic (genericShow)
+import Data.String.CaseInsensitive (CaseInsensitiveString(CaseInsensitiveString))
+import Data.TraversableWithIndex (traverseWithIndex)
+import Data.Tuple (Tuple(Tuple))
+import Effect (Effect)
+import Foreign.Object (Object, fold)
+import HTTPure.Lookup (class Lookup, (!!))
+import Node.HTTP (Request, Response, setHeaders)
+import Unsafe.Coerce (unsafeCoerce)
+
+-- | The `MultiHeaders` type represets the set of headers in a HTTP request or
+-- | response read in a way such that every header name maps to a non-empty list
+-- | of header values. This is useful for headers that may have multiple values,
+-- | such as "Set-Cookie".
+newtype MultiHeaders = MultiHeaders (Map CaseInsensitiveString (NonEmptyArray String))
+
+derive instance newtypeMultiHeaders :: Newtype MultiHeaders _
+
+derive instance genericMultiHeaders :: Generic MultiHeaders _
+
+-- | Given a string, return a `Maybe` containing the values of the matching
+-- | header, if there is any.
+instance lookupMultiHeaders :: Lookup MultiHeaders String (NonEmptyArray String) where
+  lookup (MultiHeaders headersMap) key = headersMap !! key
+
+instance showMultiHeaders :: Show MultiHeaders where
+  show = genericShow
+
+-- | Compare two `MultiHeaders` objects by comparing the underlying `Objects`.
+derive newtype instance eqMultiHeaders :: Eq MultiHeaders
+
+-- | Allow one `MultiHeaders` objects to be appended to another.
+instance semigroupMultiHeaders :: Semigroup MultiHeaders where
+  append (MultiHeaders a) (MultiHeaders b) =
+    MultiHeaders $ Data.Map.unionWith append a b
+
+-- | Return a `MultiHeaders` containing nothing.
+empty :: MultiHeaders
+empty = MultiHeaders Data.Map.empty
+
+-- | Create a singleton header from a key-value pair.
+header :: String -> String -> MultiHeaders
+header key = header' key <<< Data.Array.NonEmpty.singleton
+
+-- | Create a singleton header from a key-values pair.
+header' :: String -> NonEmptyArray String -> MultiHeaders
+header' key = MultiHeaders <<< Data.Map.singleton (CaseInsensitiveString key)
+
+-- | Convert an `Array` of `Tuples` of 2 `Strings` to a `MultiHeaders` object.
+headers :: Array (Tuple String String) -> MultiHeaders
+headers = headers' <<< map (map pure)
+
+-- | Convert an `Array` of `Tuples` of 2 `Strings` to a `MultiHeaders` object.
+headers' :: Array (Tuple String (NonEmptyArray String)) -> MultiHeaders
+headers' = foldl insertField Data.Map.empty >>> MultiHeaders
+  where
+  insertField x (Tuple key values) = Data.Map.insertWith append (CaseInsensitiveString key) values x
+
+-- | Read the headers out of a HTTP `Request` object and parse duplicated
+-- | headers as a list (instead of comma-separated values, as with
+-- | `HTTPure.Headers.read`).
+read :: Request -> MultiHeaders
+read = requestHeadersDistinct >>> fold insertField Data.Map.empty >>> MultiHeaders
+  where
+  insertField ::
+    forall a.
+    Map CaseInsensitiveString (NonEmptyArray a) ->
+    String ->
+    Array a ->
+    Map CaseInsensitiveString (NonEmptyArray a)
+  insertField headersMap key array = case Data.Array.NonEmpty.fromArray array of
+    Nothing -> headersMap
+    Just nonEmptyArray -> Data.Map.insert (CaseInsensitiveString key) nonEmptyArray headersMap
+
+  -- | Similar to `Node.HTTP.requestHeaders`, but there is no join logic and the
+  -- | values are always arrays of strings, even for headers received just once.
+  -- | See https://nodejs.org/api/http.html#messageheadersdistinct.
+  requestHeadersDistinct :: Request -> Object (Array String)
+  requestHeadersDistinct = _.headersDistinct <<< unsafeCoerce
+
+-- | Given an HTTP `Response` and a `MultiHeaders` object, return an effect that will
+-- | write the `MultiHeaders` to the `Response`.
+write :: Response -> MultiHeaders -> Effect Unit
+write response (MultiHeaders headersMap) = void $ traverseWithIndex writeField headersMap
+  where
+  writeField key = setHeaders response (unwrap key) <<< Data.Array.NonEmpty.toArray

--- a/src/HTTPure/Request.purs
+++ b/src/HTTPure/Request.purs
@@ -16,6 +16,8 @@ import HTTPure.Headers (Headers)
 import HTTPure.Headers (read) as Headers
 import HTTPure.Method (Method)
 import HTTPure.Method (read) as Method
+import HTTPure.MultiHeaders (MultiHeaders)
+import HTTPure.MultiHeaders as HTTPure.MultiHeaders
 import HTTPure.Path (Path)
 import HTTPure.Path (read) as Path
 import HTTPure.Query (Query)
@@ -33,6 +35,7 @@ type Request =
   , path :: Path
   , query :: Query
   , headers :: Headers
+  , multiHeaders :: MultiHeaders
   , body :: RequestBody
   , httpVersion :: Version
   , url :: String
@@ -60,8 +63,8 @@ fromHTTPRequest request = do
     , path: Path.read request
     , query: Query.read request
     , headers: Headers.read request
+    , multiHeaders: HTTPure.MultiHeaders.read request
     , body
     , httpVersion: Version.read request
     , url: requestURL request
     }
-

--- a/src/HTTPure/Response.purs
+++ b/src/HTTPure/Response.purs
@@ -141,6 +141,8 @@ import Effect.Class (class MonadEffect, liftEffect)
 import HTTPure.Body (class Body, defaultHeaders, write)
 import HTTPure.Headers (Headers, empty)
 import HTTPure.Headers (write) as Headers
+import HTTPure.MultiHeaders (MultiHeaders)
+import HTTPure.MultiHeaders as HTTPure.MultiHeaders
 import HTTPure.Status (Status)
 import HTTPure.Status
   ( accepted
@@ -216,6 +218,7 @@ type ResponseM = Aff Response
 type Response =
   { status :: Status
   , headers :: Headers
+  , multiHeaders :: MultiHeaders
   , writeBody :: HTTP.Response -> Aff Unit
   }
 
@@ -223,9 +226,10 @@ type Response =
 -- | a monad encapsulating writing the HTTPure `Response` to the HTTP `Response`
 -- | and closing the HTTP `Response`.
 send :: forall m. MonadEffect m => MonadAff m => HTTP.Response -> Response -> m Unit
-send httpresponse { status, headers, writeBody } = do
+send httpresponse { status, headers, multiHeaders, writeBody } = do
   liftEffect $ Status.write httpresponse status
   liftEffect $ Headers.write httpresponse headers
+  liftEffect $ HTTPure.MultiHeaders.write httpresponse multiHeaders
   liftAff $ writeBody httpresponse
 
 -- | For custom response statuses or providing a body for response codes that
@@ -247,6 +251,7 @@ response' status headers body = liftEffect do
   pure
     { status
     , headers: defaultHeaders' <> headers
+    , multiHeaders: HTTPure.MultiHeaders.empty
     , writeBody: write body
     }
 

--- a/test/Test/HTTPure/HeadersSpec.purs
+++ b/test/Test/HTTPure/HeadersSpec.purs
@@ -2,10 +2,12 @@ module Test.HTTPure.HeadersSpec where
 
 import Prelude
 
-import Data.Maybe (Maybe(Nothing, Just))
-import Data.Tuple (Tuple(Tuple))
+import Data.Map as Data.Map
+import Data.Maybe (Maybe(..))
+import Data.String.CaseInsensitive (CaseInsensitiveString(..))
+import Data.Tuple (Tuple(..))
 import Effect.Class (liftEffect)
-import HTTPure.Headers (empty, header, headers, read, write)
+import HTTPure.Headers (Headers(..), empty, header, headers, read, write)
 import HTTPure.Lookup ((!!))
 import Test.HTTPure.TestHelpers ((?=))
 import Test.HTTPure.TestHelpers as TestHelpers
@@ -31,13 +33,6 @@ lookupSpec =
     describe "when the string is not in the header set" do
       it "is Nothing" do
         ((empty !! "X-Test") :: Maybe String) ?= Nothing
-
-showSpec :: TestHelpers.Test
-showSpec =
-  describe "show" do
-    it "is a string representing the headers in HTTP format" do
-      let mock = header "Test1" "1" <> header "Test2" "2"
-      show mock ?= "Test1: 1\nTest2: 2\n\n"
 
 eqSpec :: TestHelpers.Test
 eqSpec =
@@ -104,13 +99,13 @@ emptySpec :: TestHelpers.Test
 emptySpec =
   describe "empty" do
     it "is an empty Map in an empty Headers" do
-      show empty ?= "\n"
+      empty ?= Headers Data.Map.empty
 
 headerSpec :: TestHelpers.Test
 headerSpec =
   describe "header" do
     it "creates a singleton Headers" do
-      show (header "X-Test" "test") ?= "X-Test: test\n\n"
+      header "X-Test" "test" ?= Headers (Data.Map.singleton (CaseInsensitiveString "X-Test") "test")
 
 headersFunctionSpec :: TestHelpers.Test
 headersFunctionSpec =
@@ -128,7 +123,6 @@ headersSpec :: TestHelpers.Test
 headersSpec =
   describe "Headers" do
     lookupSpec
-    showSpec
     eqSpec
     appendSpec
     readSpec

--- a/test/Test/HTTPure/MultiHeadersSpec.purs
+++ b/test/Test/HTTPure/MultiHeadersSpec.purs
@@ -1,0 +1,133 @@
+module Test.HTTPure.MultiHeadersSpec where
+
+import Prelude
+
+import Data.Array.NonEmpty (NonEmptyArray)
+import Data.Map as Data.Map
+import Data.Maybe (Maybe(..))
+import Data.String.CaseInsensitive (CaseInsensitiveString(..))
+import Data.Tuple (Tuple(..))
+import Effect.Class (liftEffect)
+import HTTPure.Lookup ((!!))
+import HTTPure.MultiHeaders (MultiHeaders(..), empty, header, header', headers, read, write)
+import Test.HTTPure.TestHelpers ((?=))
+import Test.HTTPure.TestHelpers as TestHelpers
+import Test.Spec (describe, it)
+
+lookupSpec :: TestHelpers.Test
+lookupSpec =
+  describe "lookup" do
+    describe "when the string is in the header set" do
+      describe "when searching with lowercase" do
+        it "is Just the string" do
+          header "x-test" "test" !! "x-test" ?= Just (pure "test")
+      describe "when searching with uppercase" do
+        it "is Just the string" do
+          header "x-test" "test" !! "X-Test" ?= Just (pure "test")
+      describe "when the string is uppercase" do
+        describe "when searching with lowercase" do
+          it "is Just the string" do
+            header "X-Test" "test" !! "x-test" ?= Just (pure "test")
+        describe "when searching with uppercase" do
+          it "is Just the string" do
+            header "X-Test" "test" !! "X-Test" ?= Just (pure "test")
+    describe "when the string is not in the header set" do
+      it "is Nothing" do
+        ((empty !! "X-Test") :: Maybe (NonEmptyArray String)) ?= Nothing
+
+eqSpec :: TestHelpers.Test
+eqSpec =
+  describe "eq" do
+    describe "when the two MultiHeaders contain the same keys and values" do
+      it "is true" do
+        header "Test1" "test1" == header "Test1" "test1" ?= true
+    describe "when the two MultiHeaders contain different keys and values" do
+      it "is false" do
+        header "Test1" "test1" == header "Test2" "test2" ?= false
+    describe "when the two MultiHeaders contain only different values" do
+      it "is false" do
+        header "Test1" "test1" == header "Test1" "test2" ?= false
+    describe "when the one MultiHeaders contains additional keys and values" do
+      it "is false" do
+        let mock = header "Test1" "1" <> header "Test2" "2"
+        header "Test1" "1" == mock ?= false
+
+appendSpec :: TestHelpers.Test
+appendSpec =
+  describe "append" do
+    describe "when there are multiple keys" do
+      it "appends the headers correctly" do
+        let
+          mock1 = header "Test1" "1" <> header "Test2" "2"
+          mock2 = header "Test3" "3" <> header "Test4" "4"
+          mock3 =
+            headers
+              [ Tuple "Test1" "1"
+              , Tuple "Test2" "2"
+              , Tuple "Test3" "3"
+              , Tuple "Test4" "4"
+              ]
+        mock1 <> mock2 ?= mock3
+    describe "when there is a duplicated key" do
+      it "appends the multiple values" do
+        let mock = header "Test" "foo" <> header "Test" "bar"
+        mock ?= header' "Test" (pure "foo" <> pure "bar")
+
+readSpec :: TestHelpers.Test
+readSpec =
+  describe "read" do
+    describe "with no headers" do
+      it "is an empty Map" do
+        request <- TestHelpers.mockRequest "" "" "" "" []
+        read request ?= empty
+    describe "with headers" do
+      it "is a Map with the contents of the headers" do
+        let testHeader = [ Tuple "X-Test" "test" ]
+        request <- TestHelpers.mockRequest "" "" "" "" testHeader
+        read request ?= headers testHeader
+
+writeSpec :: TestHelpers.Test
+writeSpec =
+  describe "write" do
+    it "writes the headers to the response" do
+      header <- liftEffect do
+        mock <- TestHelpers.mockResponse
+        write mock $ headers [ Tuple "X-Test" "test1", Tuple "X-Test" "test2" ]
+        pure $ TestHelpers.getResponseMultiHeader "X-Test" mock
+      header ?= [ "test1", "test2" ]
+
+emptySpec :: TestHelpers.Test
+emptySpec =
+  describe "empty" do
+    it "is an empty Map in an empty MultiHeaders" do
+      empty ?= MultiHeaders Data.Map.empty
+
+headerSpec :: TestHelpers.Test
+headerSpec =
+  describe "header" do
+    it "creates a singleton MultiHeaders" do
+      header "X-Test" "test" ?= MultiHeaders (Data.Map.singleton (CaseInsensitiveString "X-Test") (pure "test"))
+
+headersFunctionSpec :: TestHelpers.Test
+headersFunctionSpec =
+  describe "headers" do
+    it "is equivalent to using header with <>" do
+      let
+        expected = header "X-Test-1" "1" <> header "X-Test-2" "2"
+        test = headers
+          [ Tuple "X-Test-1" "1"
+          , Tuple "X-Test-2" "2"
+          ]
+      test ?= expected
+
+multiHeadersSpec :: TestHelpers.Test
+multiHeadersSpec =
+  describe "MultiHeaders" do
+    lookupSpec
+    eqSpec
+    appendSpec
+    readSpec
+    writeSpec
+    emptySpec
+    headerSpec
+    headersFunctionSpec

--- a/test/Test/HTTPure/RequestSpec.purs
+++ b/test/Test/HTTPure/RequestSpec.purs
@@ -7,6 +7,7 @@ import Foreign.Object (singleton)
 import HTTPure.Body (toString)
 import HTTPure.Headers (headers)
 import HTTPure.Method (Method(Post))
+import HTTPure.MultiHeaders as HTTPure.MultiHeaders
 import HTTPure.Request (fromHTTPRequest, fullPath)
 import HTTPure.Version (Version(HTTP1_1))
 import Test.HTTPure.TestHelpers (Test, mockRequest, (?=))
@@ -27,6 +28,9 @@ fromHTTPRequestSpec =
     it "contains the correct headers" do
       mock <- mockRequest'
       mock.headers ?= headers mockHeaders
+    it "contains the correct multi-headers" do
+      mock <- mockRequest'
+      mock.multiHeaders ?= HTTPure.MultiHeaders.headers mockHeaders
     it "contains the correct body" do
       mockBody <- mockRequest' >>= _.body >>> toString
       mockBody ?= "body"
@@ -34,7 +38,11 @@ fromHTTPRequestSpec =
       mock <- mockRequest'
       mock.httpVersion ?= HTTP1_1
   where
-  mockHeaders = [ Tuple "Test" "test" ]
+  mockHeaders =
+    [ Tuple "Test" "test"
+    , Tuple "TestMulti" "test1"
+    , Tuple "TestMulti" "test2"
+    ]
 
   mockHTTPRequest = mockRequest "1.1" "POST" "/test?a=b" "body" mockHeaders
 

--- a/test/Test/HTTPure/TestHelpers.js
+++ b/test/Test/HTTPure/TestHelpers.js
@@ -9,7 +9,8 @@ export const mockRequestImpl = httpVersion => method => url => body => headers =
     });
     stream.method = method;
     stream.url = url;
-    stream.headers = headers;
+    stream.headers = Object.fromEntries(Object.entries(headers).map(([key, values]) => [key, values[values.length - 1]]));
+    stream.headersDistinct = headers;
     stream.httpVersion = httpVersion;
 
     return stream;

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -8,6 +8,7 @@ import Test.HTTPure.HeadersSpec (headersSpec)
 import Test.HTTPure.IntegrationSpec (integrationSpec)
 import Test.HTTPure.LookupSpec (lookupSpec)
 import Test.HTTPure.MethodSpec (methodSpec)
+import Test.HTTPure.MultiHeadersSpec (multiHeadersSpec)
 import Test.HTTPure.PathSpec (pathSpec)
 import Test.HTTPure.QuerySpec (querySpec)
 import Test.HTTPure.RequestSpec (requestSpec)
@@ -27,6 +28,7 @@ main = launchAff_ $ runSpec [ specReporter ] $ describe "HTTPure" do
   headersSpec
   lookupSpec
   methodSpec
+  multiHeadersSpec
   pathSpec
   querySpec
   requestSpec


### PR DESCRIPTION
We add the `HTTPure.MultiHeaders` module and use it in `HTTPure.Request` and `HTTPure.Response` for reading and writing headers with multiple values.

We chose this approach instead of adding support for duplicated headers to `HTTPure.Headers` in order to avoid a large breaking change.

Resolves #157.