### PR TITLE
Release v0.16.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,10 @@
+0.16.0 / 2022-11-17
+===================
+- Allow multi-value headers in request and response
+- Breaking change: change the `Show` instance of `HTTPure.Headers.Headers` so
+    that it's used for debugging only. The previous behavior of `show` is now
+    available with `HTTPure.Headers.toString`.
+
 0.15.0 / 2022-05-05
 ===================
 - Update for PureScript 0.15 (thanks **@thomashoneyman** and **@sigma-andex**)

--- a/Releasing.md
+++ b/Releasing.md
@@ -13,7 +13,7 @@
 3. Commit your update to [History.md](./History.md). Use the message `Release
    notes for v<new version number>`.
 4. Follow the instructions on
-   https://discourse.purescript.org/t/how-i-publish-a-purescript-package/2482.
+   https://github.com/purescript-contrib/governance/blob/main/pursuit-preregistry.md.
 5. If you are pushing a non-patch release, create and push a branch named with
    the version series, i.e. `v0.1.x`.
 6. [Create the release on


### PR DESCRIPTION
Turns out that the `main` branch is protected so the release process outlined in https://github.com/citizennet/purescript-httpure/blob/main/Releasing.md needs an extra PR for updating `main`.